### PR TITLE
Bugfix zero itanal

### DIFF
--- a/R/cq_itanal.R
+++ b/R/cq_itanal.R
@@ -51,15 +51,15 @@ cq_read_itanal <- function(fname) {
 
   # response stats
   resp_col_names <- c("label", "score", "count", "pct_tot", "pt_bis", "t", "p",
-                      "blank", "pv_avg", "pv_sd")
+                      "pv_avg", "pv_sd")
+
   txt <- txt %>%
     dplyr::mutate(resp_stat = purrr::map(.data$resp_stat, function(x) {
       x <- x %>%
         stringr::str_trim() %>%
-        stringr::str_split("\\s+|\\(|\\)") %>%
+        stringr::str_split("[\\s\\(\\)]+") %>%
         purrr::map(setNames, resp_col_names) %>%
-        purrr::map_dfr(as.list) %>%
-        dplyr::select(-.data$blank)
+        purrr::map_dfr(as.list)
       x
     }))
 

--- a/inst/extdata/edge_case/one_item.itn
+++ b/inst/extdata/edge_case/one_item.itn
@@ -1,0 +1,39 @@
+=================================================================================
+ex1                                                        Tue Nov 21 13:58 2017
+GENERALISED ITEM ANALYSIS
+=================================================================================
+Item 8
+------
+item:8 (q8)
+Cases for this item   1475   Discrimination  0.57
+Item Threshold(s):    -0.10   Weighted MNSQ   1.11
+Item Delta(s):        -0.10
+------------------------------------------------------------------------------
+ Label    Score     Count   % of tot  Pt Bis     t  (p)   PV1Avg:1 PV1 SD:1
+------------------------------------------------------------------------------
+   1       0.00       45       3.05   -0.14    -5.50(.000) -1.45     2.17
+   2       0.00       50       3.39   -0.05    -2.08(.038) -0.27     1.32
+   3       1.00      872      59.12    0.57    26.34(.000)  1.68     1.75
+   4       0.00       47       3.19   -0.01    -0.56(.575)  0.12     1.35
+   5       0.00      169      11.46    0.01     0.20(.839)  0.15     1.62
+   9       0.00      292      19.80   -0.61   -29.56(.000) -1.93     1.29
+==============================================================================
+
+------------------------------------------------------------------------------
+The following traditional statistics are only meaningful for complete
+designs and when the amount of missing data is minimal.
+In this analysis  0.00%  of the data are missing.
+
+The following results are scaled to assume that a single response
+was provided for each item.
+
+N                               1475
+Mean                            5.15
+Standard Deviation              3.01
+Variance                        9.03
+Skewness                       -0.23
+Kurtosis                       -1.35
+Standard error of mean          0.08
+Standard error of measurement   1.10
+Coefficient Alpha               0.87
+==============================================================================

--- a/inst/extdata/edge_case/one_resp_code.itn
+++ b/inst/extdata/edge_case/one_resp_code.itn
@@ -1,0 +1,34 @@
+=================================================================================
+ex1                                                        Tue Nov 21 13:58 2017
+GENERALISED ITEM ANALYSIS
+=================================================================================
+Item 25
+-------
+item:25 (one_resp_code)
+Cases for this item    356   Discrimination NA
+Item Threshold(s): NOT AVAILABLE   Weighted MNSQ: NOT AVAILABLE
+Item Delta(s): NOT AVAILABLE
+------------------------------------------------------------------------------
+ Label    Score     Count   % of tot  Pt Bis     t  (p)   PV1Avg:1 PV1 SD:1
+------------------------------------------------------------------------------
+   0       0.00      356     100.00     NA       NA (.000) -0.22     0.96
+==============================================================================
+
+------------------------------------------------------------------------------
+The following traditional statistics are only meaningful for complete
+designs and when the amount of missing data is minimal.
+In this analysis  0.00%  of the data are missing.
+
+The following results are scaled to assume that a single response
+was provided for each item.
+
+N                               1475
+Mean                            5.15
+Standard Deviation              3.01
+Variance                        9.03
+Skewness                       -0.23
+Kurtosis                       -1.35
+Standard error of mean          0.08
+Standard error of measurement   1.10
+Coefficient Alpha               0.87
+==============================================================================

--- a/inst/extdata/edge_case/zero_item.itn
+++ b/inst/extdata/edge_case/zero_item.itn
@@ -1,0 +1,35 @@
+=================================================================================
+ex1                                                        Tue Nov 21 13:58 2017
+GENERALISED ITEM ANALYSIS
+=================================================================================
+Item 106
+--------
+item:106 (I_am_a_zero_item)
+Cases for this item    357   Discrimination NA
+Item Threshold(s): NOT AVAILABLE   Weighted MNSQ: NOT AVAILABLE
+Item Delta(s): NOT AVAILABLE
+------------------------------------------------------------------------------
+ Label    Score     Count   % of tot  Pt Bis     t  (p)   PV1Avg:1 PV1 SD:1
+------------------------------------------------------------------------------
+   0       0.00      356      99.72    0.05     0.95(.341) -0.27     0.98
+   9       0.00        1       0.28   -0.05    -0.95(.341) -0.92     0.00
+==============================================================================
+
+------------------------------------------------------------------------------
+The following traditional statistics are only meaningful for complete
+designs and when the amount of missing data is minimal.
+In this analysis  0.00%  of the data are missing.
+
+The following results are scaled to assume that a single response
+was provided for each item.
+
+N                               1475
+Mean                            5.15
+Standard Deviation              3.01
+Variance                        9.03
+Skewness                       -0.23
+Kurtosis                       -1.35
+Standard error of mean          0.08
+Standard error of measurement   1.10
+Coefficient Alpha               0.87
+==============================================================================

--- a/tests/testthat/test-cq_itanal.R
+++ b/tests/testthat/test-cq_itanal.R
@@ -18,3 +18,10 @@ test_that("import zero item", {
   expect_equal(nrow(zero_item), 1)
   expect_equal(trimws(zero_item$id), "item:106 (I_am_a_zero_item)")
 })
+
+test_that("item with one response code", {
+  x <- cq_itanal(system.file("extdata", "edge_case", "one_resp_code.itn", package = "conquestr"))
+  expect_equal(nrow(x), 1)
+  expect_equal(trimws(x$id), "item:25 (one_resp_code)")
+})
+

--- a/tests/testthat/test-cq_itanal.R
+++ b/tests/testthat/test-cq_itanal.R
@@ -6,3 +6,15 @@ test_that("Values imported correctly", {
   expect_equal(unique(df$case), 1475)
   expect_equal(df$disc[4], 0.780)
 })
+
+test_that("import one item", {
+  one_item <- cq_itanal(system.file("extdata", "edge_case", "one_item.itn", package = "conquestr"))
+  expect_equal(nrow(one_item), 1)
+  expect_equal(one_item$item_index, "8")
+})
+
+test_that("import zero item", {
+  zero_item <- cq_itanal(system.file("extdata", "edge_case", "zero_item.itn", package = "conquestr"))
+  expect_equal(nrow(zero_item), 1)
+  expect_equal(trimws(zero_item$id), "item:106 (I_am_a_zero_item)")
+})


### PR DESCRIPTION
This PR is to Fix #11.  

The existing process for splitting the response statistics (resp_stats) failed when statistics such as the t value has text NA instead of a numeric value. `cq_itanal` has been updated and additional tests added for these edge cases.